### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add id to your [jekyll _config.yml](https://jekyllrb.com/docs/configuration/):
 
 ```yaml
 plugins:
-  - image-size
+  - jekyll-image-size
 ```
 
 ## File Types Supported


### PR DESCRIPTION
Updated installation documentation. Users should write the full plugin name in `_config` otherwise Jekyll looks for what it deems missing dependencies and throws an error like 
```Dependency Error: Yikes! It looks like you don't have image-size or one of its dependencies installed.```