### PR TITLE
Add the source directory to the image path.

### DIFF
--- a/lib/jekyll-image-size.rb
+++ b/lib/jekyll-image-size.rb
@@ -28,6 +28,9 @@ class ImageSizeTag < Liquid::Tag
     rawSource = source
 
     source = source.sub(/^\//, '')
+    if context
+        source = File.join(context.registers[:site].source, source)
+    end
 
     size = FastImage.size(source)
     if context && !size

--- a/lib/jekyll-image-size/version.rb
+++ b/lib/jekyll-image-size/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module ImageSize
-    VERSION = "1.2.1"
+    VERSION = "1.2.2"
   end
 end


### PR DESCRIPTION
This solves an issue where the system does not work if the Jekyll build -s argument is passed in with
some source directory other than the current working directory.